### PR TITLE
Using Validators for config and using false outcome instead of throwing exception

### DIFF
--- a/src/main/java/org/forgerock/openam/auth/nodes/WindowsDesktopSSONode.java
+++ b/src/main/java/org/forgerock/openam/auth/nodes/WindowsDesktopSSONode.java
@@ -193,7 +193,7 @@ public class WindowsDesktopSSONode extends AbstractDecisionNode {
         try {
             username = authenticateToken(serviceSubject, kerberosToken, config.trustedKerberosRealms());
             if (username != null && !username.isEmpty()) {
-                return goTo(true).replaceSharedState(newSharedState).build();
+                return setUserNameAndReturnTrue(username, newSharedState);
             }
         } catch (PrivilegedActionException pe) {
             Exception e = extractException(pe);
@@ -207,7 +207,7 @@ public class WindowsDesktopSSONode extends AbstractDecisionNode {
                         username = authenticateToken(serviceSubject, kerberosToken, config.trustedKerberosRealms());
                         if (username != null && !username.isEmpty()) {
                             logger.debug("Authentication succeeded with new cred.");
-                            return goTo(true).replaceSharedState(newSharedState).build();
+                            return setUserNameAndReturnTrue(username, newSharedState);
                         }
                     } catch (PrivilegedActionException ex) {
                         logger.error("Error while validating kerberos token", ex);
@@ -224,6 +224,13 @@ public class WindowsDesktopSSONode extends AbstractDecisionNode {
     private Action logErrorAndReturnFalse(JsonValue newSharedState, String text, Object... objects) {
         logger.error(text, objects);
         return goTo(false).replaceSharedState(newSharedState).build();
+    }
+
+    private Action setUserNameAndReturnTrue(String username, JsonValue newSharedState) {
+        if (username != null) {
+            newSharedState.put(SharedStateConstants.USERNAME, username);
+        }
+        return goTo(true).replaceSharedState(newSharedState).build();
     }
 
     private String authenticateToken(final Subject serviceSubject, final byte[] kerberosToken,

--- a/src/main/java/org/forgerock/openam/sm/validation/FileExistenceValidator.java
+++ b/src/main/java/org/forgerock/openam/sm/validation/FileExistenceValidator.java
@@ -20,7 +20,7 @@ public class FileExistenceValidator implements ServiceAttributeValidator {
         }
 
         for (String value : set) {
-            if (!Files.exists(Paths.get(value))) {
+            if (!Files.exists(Paths.get(value)) || value.isEmpty()) {
                 return false;
             }
         }

--- a/src/main/java/org/forgerock/openam/sm/validation/FileExistenceValidator.java
+++ b/src/main/java/org/forgerock/openam/sm/validation/FileExistenceValidator.java
@@ -1,0 +1,30 @@
+package org.forgerock.openam.sm.validation;
+
+import com.sun.identity.sm.ServiceAttributeValidator;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Set;
+
+/**
+ * {@link ServiceAttributeValidator} which validates that given set contains Strings which are valid paths to existing files.
+ * Also ensure that the Set contains at minimum one value
+ */
+public class FileExistenceValidator implements ServiceAttributeValidator {
+
+    @Override
+    public boolean validate(Set<String> set) {
+
+        if (set == null || set.isEmpty()) {
+            return false;
+        }
+
+        for (String value : set) {
+            if (!Files.exists(Paths.get(value))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
- Validators in config ensure that config is validated when it is configured and does not require that  it is validated during each auth process
- If NodeProcessException is thrown, error handling is not possible (error message, offering username/password login etc.). 

Maybe useful extension